### PR TITLE
fix: add array to validatedCountry union

### DIFF
--- a/src/Forms/PhoneInput.php
+++ b/src/Forms/PhoneInput.php
@@ -56,7 +56,7 @@ class PhoneInput extends Field
 
     public bool $canPerformIpLookup = true;
 
-    public ?string $validatedCountry = null;
+    public string|array $validatedCountry = [];
 
     public string|Closure|null $countryStatePath = null;
 


### PR DESCRIPTION
This PR adds an array to the validatedCountry property since the first parameter of `validateFor` method accepts a string or array.