### PR TITLE
allowing array as value for type parameter in PhoneInput@validateFor

### DIFF
--- a/src/Forms/PhoneInput.php
+++ b/src/Forms/PhoneInput.php
@@ -199,7 +199,7 @@ class PhoneInput extends Field
         return $this->generateRelativeStatePath($this->countryStatePath, $this->countryStatePathIsAbsolute);
     }
 
-    public function validateFor(string | array $country = 'AUTO', ?int $type = null, bool $lenient = false)
+    public function validateFor(string | array $country = 'AUTO', int|array|null $type = null, bool $lenient = false)
     {
         $this->validatedCountry = $country;
 


### PR DESCRIPTION
Since Propaganistas\LaravelPhone\Rules\Phone accepts an array as well