### PR TITLE
Fixed path to `use PhoneInputNumberType;`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ use Filament\Infolists\Infolist;
 use Ysfkaya\FilamentPhoneInput\Forms\PhoneInput;
 use Ysfkaya\FilamentPhoneInput\Tables\PhoneColumn;
 use Ysfkaya\FilamentPhoneInput\Infolists\PhoneEntry;
-use Ysfkaya\FilamentPhoneInput\Infolists\PhoneInputNumberType;
+use Ysfkaya\FilamentPhoneInput\PhoneInputNumberType;
 
   
     public static function infolists(Infolist $infolist): Infolist


### PR DESCRIPTION
Thanks so much for this super handy plugin! This `use` namespace was not resolved ing for me, and in looking in the vendors directory, it seems to be one level up from Infolists.