### PR TITLE
Fix RTL Phone Number Display

### DIFF
--- a/src/Infolists/PhoneEntry.php
+++ b/src/Infolists/PhoneEntry.php
@@ -46,13 +46,13 @@ class PhoneEntry extends TextEntry
 
                 $format = $format->toLibPhoneNumberFormat();
 
-                if ($format === PhoneNumberFormat::RFC3966) {
-                    $formatted = phone(
-                        number: $state,
-                        country: $country,
-                        format: $format
-                    );
+                $formatted = phone(
+                    number: $state,
+                    country: $country,
+                    format: $format
+                );
 
+                if ($format === PhoneNumberFormat::RFC3966) {
                     $national = phone(
                         number: $state,
                         country: $country,
@@ -60,19 +60,19 @@ class PhoneEntry extends TextEntry
                     );
 
                     $html = <<<HTML
-                        <a href="$formatted">
+                        <a href="$formatted" dir="ltr">
                             $national
                         </a>
                     HTML;
-
-                    return new HtmlString($html);
+                } else {
+                    $html = <<<HTML
+                        <span dir="ltr">
+                            $formatted
+                        </span>
+                    HTML;
                 }
 
-                return phone(
-                    number: $state,
-                    country: $country,
-                    format: $format
-                );
+                return new HtmlString($html);
             } catch (NumberParseException $e) {
                 return $state;
             }

--- a/src/Tables/PhoneColumn.php
+++ b/src/Tables/PhoneColumn.php
@@ -46,13 +46,13 @@ class PhoneColumn extends TextColumn
 
                 $format = $format->toLibPhoneNumberFormat();
 
-                if ($format === PhoneNumberFormat::RFC3966) {
-                    $formatted = phone(
-                        number: $state,
-                        country: $country,
-                        format: $format
-                    );
+                $formatted = phone(
+                    number: $state,
+                    country: $country,
+                    format: $format
+                );
 
+                if ($format === PhoneNumberFormat::RFC3966) {
                     $national = phone(
                         number: $state,
                         country: $country,
@@ -60,19 +60,22 @@ class PhoneColumn extends TextColumn
                     );
 
                     $html = <<<HTML
-                        <a href="$formatted">
+                        <a href="$formatted" dir="ltr">
                             $national
                         </a>
                     HTML;
 
-                    return new HtmlString($html);
+
+                } else {
+                    $html = <<<HTML
+                        <span dir="ltr">
+                            $formatted
+                        </span>
+                    HTML;
                 }
 
-                return phone(
-                    number: $state,
-                    country: $country,
-                    format: $format
-                );
+
+                return new HtmlString($html);
             } catch (NumberParseException $e) {
                 return $state;
             }


### PR DESCRIPTION
Currently, when the app is set to `dir="rtl"`, phone numbers are displayed incorrectly, like this: **987-654-3210 +1**. This PR adds `dir="ltr"` to the infolist and table entries to ensure they are displayed correctly.