### PR TITLE
Fix Alpine directive from 'ax-' to 'x-' in phone input view

### DIFF
--- a/resources/views/phone-input.blade.php
+++ b/resources/views/phone-input.blade.php
@@ -76,13 +76,12 @@
         >
             <div
                 class="w-full"
-                x-ignore
                 @if (FilamentView::hasSpaMode())
-                    {{-- format-ignore-start --}}ax-load="visible || event (ax-modal-opened)" {{-- format-ignore-end --}}
+                    {{-- format-ignore-start --}}x-load="visible || event (ax-modal-opened)" {{-- format-ignore-end --}}
                 @else
-                    ax-load
+                    x-load
                 @endif
-                ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-phone-input', package: 'ysfkaya/filament-phone-input') }}"
+                x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-phone-input', package: 'ysfkaya/filament-phone-input') }}"
                 x-data="phoneInputFormComponent({
                     options: {
                         allowDropdown: @js($isAllowDropdown()),

--- a/tests/Browser/views/components/layouts/app.blade.php
+++ b/tests/Browser/views/components/layouts/app.blade.php
@@ -3,7 +3,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
     <script
-        src="https://cdn.jsdelivr.net/npm/async-alpine@1.x.x/dist/async-alpine.script.js"
+        src="https://cdn.jsdelivr.net/npm/async-alpine@2.x.x/dist/async-alpine.script.js"
         defer
     ></script>
     <script


### PR DESCRIPTION
Closes #66 
Replaced incorrect 'ax-' Alpine.js directives with the correct 'x-' prefix. This ensures proper functionality of the phone input component in both SPA and non-SPA modes.