### PR TITLE
Update PhoneInputNumberType.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     },
     "scripts": {
-        "analyse": "vendor/bin/phpstan analyse",
+        "analyse": "vendor/bin/phpstan analyse --memory-limit=512M",
         "test": "vendor/bin/pest --testsuite=Unit",
         "test-browser": "vendor/bin/phpunit --testsuite=Browser --bootstrap=tests/Browser/bootstrap.php",
         "format": "vendor/bin/pint",

--- a/src/Forms/PhoneInput.php
+++ b/src/Forms/PhoneInput.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\Field;
 use Filament\Pages\Page;
 use Filament\Support\RawJs;
 use Illuminate\Support\Facades\Http;
+use libphonenumber\PhoneNumberType;
 use Propaganistas\LaravelPhone\Rules\Phone as PhoneRule;
 use Ysfkaya\FilamentPhoneInput\PhoneInputNumberType;
 
@@ -217,9 +218,13 @@ class PhoneInput extends Field implements HasAffixActions
         return $this->generateRelativeStatePath($path, $this->countryStatePathIsAbsolute);
     }
 
-    public function validateFor(string | array $country = 'AUTO', int | array | null $type = null, bool $lenient = false)
+    public function validateFor(string | array $country = 'AUTO', int | array | PhoneNumberType | null $type = null, bool $lenient = false)
     {
         $this->validatedCountry = $country;
+
+        if ($type) {
+            $type = $type instanceof PhoneNumberType ? (enum_exists(PhoneNumberType::class) ? $type->value : $type) : $type;
+        }
 
         $rule = (new PhoneRule)->country($country)->type($type);
 

--- a/src/Infolists/PhoneEntry.php
+++ b/src/Infolists/PhoneEntry.php
@@ -54,7 +54,7 @@ class PhoneEntry extends TextEntry
                     format: $format
                 );
 
-                if ($format === PhoneNumberFormat::RFC3966) {
+                if ($format === (enum_exists(PhoneNumberFormat::class) ? PhoneNumberFormat::RFC3966->value : PhoneNumberFormat::RFC3966)) {
                     $national = phone(
                         number: $state,
                         country: $country,

--- a/src/PhoneInputNumberType.php
+++ b/src/PhoneInputNumberType.php
@@ -11,13 +11,16 @@ enum PhoneInputNumberType: string
     case NATIONAL = 'NATIONAL';
     case RFC3966 = 'RFC3966';
 
-    public function toLibPhoneNumberFormat(): int
-    {
-        return match ($this) {
-            self::E164 => PhoneNumberFormat::E164,
-            self::INTERNATIONAL => PhoneNumberFormat::INTERNATIONAL,
-            self::NATIONAL => PhoneNumberFormat::NATIONAL,
-            self::RFC3966 => PhoneNumberFormat::RFC3966,
-        };
-    }
+   public function toLibPhoneNumberFormat(): int
+{
+    $format = match ($this) {
+        self::E164 => PhoneNumberFormat::E164,
+        self::INTERNATIONAL => PhoneNumberFormat::INTERNATIONAL,
+        self::NATIONAL => PhoneNumberFormat::NATIONAL,
+        self::RFC3966 => PhoneNumberFormat::RFC3966,
+    };
+    
+    // Handle both enum and integer constant cases
+    return enum_exists(PhoneNumberFormat::class) ? $format->value : $format;
+}
 }

--- a/src/PhoneInputNumberType.php
+++ b/src/PhoneInputNumberType.php
@@ -11,16 +11,15 @@ enum PhoneInputNumberType: string
     case NATIONAL = 'NATIONAL';
     case RFC3966 = 'RFC3966';
 
-   public function toLibPhoneNumberFormat(): int
-{
-    $format = match ($this) {
-        self::E164 => PhoneNumberFormat::E164,
-        self::INTERNATIONAL => PhoneNumberFormat::INTERNATIONAL,
-        self::NATIONAL => PhoneNumberFormat::NATIONAL,
-        self::RFC3966 => PhoneNumberFormat::RFC3966,
-    };
-    
-    // Handle both enum and integer constant cases
-    return enum_exists(PhoneNumberFormat::class) ? $format->value : $format;
-}
+    public function toLibPhoneNumberFormat(): int
+    {
+        $format = match ($this) {
+            self::E164 => PhoneNumberFormat::E164,
+            self::INTERNATIONAL => PhoneNumberFormat::INTERNATIONAL,
+            self::NATIONAL => PhoneNumberFormat::NATIONAL,
+            self::RFC3966 => PhoneNumberFormat::RFC3966,
+        };
+
+        return enum_exists(PhoneNumberFormat::class) ? (function_exists('enum_value') ? enum_value($format) : $format->value) : $format;
+    }
 }

--- a/src/Tables/PhoneColumn.php
+++ b/src/Tables/PhoneColumn.php
@@ -54,7 +54,7 @@ class PhoneColumn extends TextColumn
                     format: $format
                 );
 
-                if ($format === PhoneNumberFormat::RFC3966) {
+                if ($format === (enum_exists(PhoneNumberFormat::class) ? PhoneNumberFormat::RFC3966->value : PhoneNumberFormat::RFC3966)) {
                     $national = phone(
                         number: $state,
                         country: $country,


### PR DESCRIPTION
Update Description
A change has been made to the PhoneInputNumberType class due to the implementation of PHP 8.1 Enum features in our library. This change was necessary because the libphonenumber\PhoneNumberFormat class now uses an enum structure instead of constants. Change Details

The toLibPhoneNumberFormat() method has been updated to return an integer value directly instead of an enum object We now use the enum's value property to convert to the integer format This change resolves the type mismatch error ("Return value must be of type int")

Affected Files

Ysfkaya\FilamentPhoneInput\PhoneInputNumberType.php

This update ensures compatibility with the latest version of the libphonenumber library.