### PR TITLE
Resolve CVE-2025-9288

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@tailwindcss/typography": "^0.5.9",
         "esbuild": "^0.19.2",
         "laravel-mix": "^6.0.43",
+        "sha.js": "^2.4.12",
         "tailwindcss": "^3.3.3"
     },
     "private": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -4949,6 +4949,15 @@ sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+sha.js@^2.4.12:
+  version "2.4.12"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.12.tgz#eb8b568bf383dfd1867a32c3f2b74eb52bdbf23f"
+  integrity sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==
+  dependencies:
+    inherits "^2.0.4"
+    safe-buffer "^5.2.1"
+    to-buffer "^1.2.0"
+
 shallow-clone@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"


### PR DESCRIPTION
Resolves CVE-2025-9288 mentioned in #96.

I am not very familiar with `yarn` but from what I can find, unlike `npm` it is not possible to just update a `yarn.lock` to bump a nested dependency in `yarn` V1. So setting this in the `package.json` and upgrading seems to be the best option.