### PR TITLE
Feature: publishes public asset group tag

### DIFF
--- a/src/FilamentPhoneInputServiceProvider.php
+++ b/src/FilamentPhoneInputServiceProvider.php
@@ -32,5 +32,9 @@ class FilamentPhoneInputServiceProvider extends PackageServiceProvider
         $this->publishes([
             $this->package->basePath('/../images/vendor/intl-tel-input/build') => public_path("vendor/{$this->package->shortName()}"),
         ], "{$this->package->shortName()}-assets");
+
+        $this->publishes([
+            $this->package->basePath('/../images/vendor/intl-tel-input/build') => public_path("vendor/{$this->package->shortName()}"),
+        ], "public");
     }
 }


### PR DESCRIPTION
Following the documentation: https://laravel.com/docs/12.x/packages#public-assets

This PR adds "public" published asset group, to publish assets using standard Laravel command:

```
php artisan vendor:publish --tag=public --force
```