### PR TITLE
fix: use unconditional x-load for intl-tel-input initialization In SP…

### DIFF
--- a/resources/views/phone-input.blade.php
+++ b/resources/views/phone-input.blade.php
@@ -1,5 +1,4 @@
 @php
-    use Filament\Support\Facades\FilamentView;
     use Illuminate\Support\Js;
 
     $hasInlineLabel = $hasInlineLabel();
@@ -77,11 +76,7 @@
         >
             <div
                 class="w-full"
-                @if (FilamentView::hasSpaMode())
-                    {{-- format-ignore-start --}}x-load="visible || event (ax-modal-opened)" {{-- format-ignore-end --}}
-                @else
-                    x-load
-                @endif
+                x-load
                 x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-phone-input', package: 'ysfkaya/filament-phone-input') }}"
                 x-data="phoneInputFormComponent({
                     options: {


### PR DESCRIPTION
fix: use unconditional x-load for intl-tel-input initialization In SPA mode, x-load="visible || event (ax-modal-opened)" relies on IntersectionObserver to detect element visibility. In nested Filament modals (e.g. a createOptionForm inside another action modal), the IntersectionObserver fails to fire on Windows (on macOS observer fires correctly), causing intl-tel-input to never initialize - no country flag renders, phone formatting does not work, and validation rejects user input because the Livewire state is never synced.

Replace the conditional SPA-mode loading with unconditional x-load. This still uses Alpine's async component loading (code-split), so the JS bundle is loaded lazily - only the extra visibility/event gating is removed.